### PR TITLE
Change service uri domain for graphql

### DIFF
--- a/src/brainly.js
+++ b/src/brainly.js
@@ -21,7 +21,7 @@ const Brainly = async (query, count) => {
 	_required(query);
 
 	let service = {
-		uri: 'https://brainly.com/graphql/id',
+		uri: 'https://brainly.co.id/graphql/id',
 		json: true,
 		headers: {
 			'host': 'brainly.co.id',


### PR DESCRIPTION
Don't forget to upload new npm version for this, brainly host move it's domain from .com to .co.id.

v1.0.2 or latest npm package still use .com